### PR TITLE
[JENKINS-34131] Upgrade to plugin parent pom 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.6</version>
+        <version>2.12</version>
     </parent>
     <artifactId>windows-slaves</artifactId>
     <version>1.2-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
             <groupId>org.jenkins-ci</groupId>
             <artifactId>windows-remote-command</artifactId>
             <version>1.4</version>
+            <exclusions>
+               <exclusion>
+                  <groupId>org.jvnet</groupId>
+                  <artifactId>tiger-types</artifactId>
+               </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.554.3</version>
+        <version>2.6</version>
     </parent>
     <artifactId>windows-slaves</artifactId>
     <version>1.2-SNAPSHOT</version>
@@ -22,7 +22,12 @@
         <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
       <tag>HEAD</tag>
-  </scm>
+   </scm>
+   <properties>
+      <jenkins.version>1.554.3</jenkins.version>
+      <java.level>6</java.level>
+   </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
       <tag>HEAD</tag>
    </scm>
    <properties>
-      <jenkins.version>1.554.3</jenkins.version>
+      <jenkins.version>1.580.1</jenkins.version>
       <java.level>6</java.level>
    </properties>
 

--- a/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
+++ b/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
@@ -492,7 +492,7 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
             if (node != null) {
                 String id = generateServiceId(node.getRemoteFS());
                 Win32Service slaveService = services.getService(id);
-                if(slaveService!=null) {
+                if(slaveService != null) {
                     listener.getLogger().println(Messages.ManagedWindowsServiceLauncher_StoppingService(getTimestamp()));
                     slaveService.StopService();
                     listener.getLogger().println(Messages.ManagedWindowsServiceLauncher_UnregisteringService(getTimestamp()));

--- a/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
+++ b/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
@@ -73,6 +73,8 @@ import org.jvnet.hudson.wmi.WMI;
 import org.jvnet.hudson.wmi.Win32Service;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 /**
  * Windows slave installed/managed as a service entirely remotely
  *
@@ -385,6 +387,7 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
     }
 
     // -- duplicates code from ssh-slaves-plugin
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "https://github.com/jenkinsci/jenkins/pull/2094")
     private EnvVars getEnvVars(SlaveComputer computer) {
         final EnvVars global = getEnvVars(Jenkins.getInstance());
 
@@ -444,6 +447,7 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
         }
     }
     
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "https://github.com/jenkinsci/jenkins/pull/2094")
     private String createAndCopyJenkinsSlaveXml(String java, String serviceId, PrintStream logger, SmbFile remoteRoot) throws IOException {
         logger.println(Messages.ManagedWindowsServiceLauncher_CopyingSlaveXml(getTimestamp()));
         String xml = generateSlaveXml(serviceId,
@@ -452,6 +456,7 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
         return xml;
     }
 
+    @SuppressFBWarnings(value = "NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE", justification = "https://github.com/jenkinsci/jenkins/pull/2094")
     private void copySlaveJar(PrintStream logger, SmbFile remoteRoot) throws IOException {
         // copy slave.jar
         logger.println(Messages.ManagedWindowsServiceLauncher_CopyingSlaveJar(getTimestamp()));

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,4 @@
+<?jelly escape-by-default='true'?>
 <div>
     Allows you to connect to Windows machines and start slave agents on them.
 </div>


### PR DESCRIPTION
- [x] Bump to baseline 1.580.1
- [x] Upgrade to plugin parent pom 2.6
- [x] Fix Findbugs errors
- [x] Make tests pass with latest Jenkins baseline
- [x] Exclude dependency (org.jvnet.tiger-types) in conflict with the one provided by parent pom, causing errors in tests when 1.652+ baseline is used.

@reviewbybees 
