### PR TITLE
[JENKINS-42746] - Make the plugin independent from the XML sample in the core

### DIFF
--- a/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
+++ b/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
@@ -291,6 +291,7 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
 
                 // copy exe
                 logger.println(Messages.ManagedWindowsServiceLauncher_CopyingSlaveExe(getTimestamp()));
+                //TODO: This executable in the core is designed for the master, not for the core
                 copyStreamAndClose(getClass().getResource("/windows-service/jenkins.exe").openStream(), new SmbFile(remoteRoot,"jenkins-slave.exe").getOutputStream());
 
                 copyStreamAndClose(getClass().getResource("/windows-service/jenkins.exe.config").openStream(), new SmbFile(remoteRoot,"jenkins-slave.exe.config").getOutputStream());
@@ -453,7 +454,7 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
     
     private String createAndCopyJenkinsSlaveXml(String java, String serviceId, PrintStream logger, SmbFile remoteRoot) throws IOException {
         logger.println(Messages.ManagedWindowsServiceLauncher_CopyingSlaveXml(getTimestamp()));
-        String xml = generateSlaveXml(serviceId,
+        String xml = generateSlaveXml(getClass(), serviceId,
                 java + "w.exe", vmargs, "-tcp %BASE%\\port.txt");
         copyStreamAndClose(new ByteArrayInputStream(xml.getBytes("UTF-8")), new SmbFile(remoteRoot,"jenkins-slave.xml").getOutputStream());
         return xml;
@@ -516,8 +517,8 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
         return "jenkinsslave-"+slaveRoot.replace(':','_').replace('\\','_').replace('/','_');
     }
 
-    String generateSlaveXml(String id, String java, String vmargs, String args) throws IOException {
-        String xml = org.apache.commons.io.IOUtils.toString(getClass().getResourceAsStream("/windows-service/jenkins-slave.xml"), "UTF-8");
+    static String generateSlaveXml(Class<?> clazz, String id, String java, String vmargs, String args) throws IOException {
+        String xml = org.apache.commons.io.IOUtils.toString(clazz.getResourceAsStream("configsamples/jenkins-slave.xml"), "UTF-8");
         xml = xml.replace("@ID@", id);
         xml = xml.replace("@JAVA@", java);
         xml = xml.replace("@VMARGS@", StringUtils.defaultString(vmargs));

--- a/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
+++ b/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
@@ -291,7 +291,8 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
 
                 // copy exe
                 logger.println(Messages.ManagedWindowsServiceLauncher_CopyingSlaveExe(getTimestamp()));
-                //TODO: This executable in the core is designed for the master, not for the core
+                //TODO: This executable in the core is designed for the master, not for the agents
+                // Ideally the resources from Windows Agent Installer Module should be used instead (JENKINS-42743)
                 copyStreamAndClose(getClass().getResource("/windows-service/jenkins.exe").openStream(), new SmbFile(remoteRoot,"jenkins-slave.exe").getOutputStream());
 
                 copyStreamAndClose(getClass().getResource("/windows-service/jenkins.exe.config").openStream(), new SmbFile(remoteRoot,"jenkins-slave.exe.config").getOutputStream());

--- a/src/main/resources/hudson/os/windows/configsamples/jenkins-slave.xml
+++ b/src/main/resources/hudson/os/windows/configsamples/jenkins-slave.xml
@@ -1,0 +1,84 @@
+<!--
+The MIT License
+
+Copyright (c) 2004-2017, Sun Microsystems, Inc., Kohsuke Kawaguchi, Oleg Nenashev and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+
+<!--
+  Windows service definition for Jenkins agent.
+  This service is powered by the WinSW project: https://github.com/kohsuke/winsw/
+
+  You can find more information about available options here: https://github.com/kohsuke/winsw/blob/master/doc/xmlConfigFile.md
+  Configuration examples are available here: https://github.com/kohsuke/winsw/tree/master/examples
+
+  To uninstall, run "jenkins-slave.exe stop" to stop the service, then "jenkins-slave.exe uninstall" to uninstall the service.
+  Both commands don't produce any output if the execution is successful.
+-->
+<!--
+  TODO: this is a copy of the configuration file in Windows Agent Installer module 1.7 stored directly in windlows-slaves plugin
+  As per JENKINS-42743, the agent should use the module's API
+-->
+<service>
+  <id>@ID@</id>
+  <name>Jenkins agent (@ID@)</name>
+  <description>This service runs an agent for Jenkins automation server.</description>
+  <!--
+    if you'd like to run Jenkins with a specific version of Java, specify a full path to java.exe.
+    The following value assumes that you have java in your PATH.
+  -->
+  <executable>@JAVA@</executable>
+  <arguments>-Xrs @VMARGS@ -jar "%BASE%\slave.jar" @ARGS@</arguments>
+  <!--
+    interactive flag causes the empty black Java window to be displayed.
+    I'm still debugging this.
+  <interactive />
+  -->
+  <logmode>rotate</logmode>
+
+  <onfailure action="restart" />
+  
+  <!--
+    If uncommented, download the Remoting version provided by the Jenkins master.
+    Enabling for HTTP implies security risks (e.g. replacement of JAR via DNS poisoning). Use on your own risk.
+    NOTE: This option may fail to work correctly (e.g. if Jenkins is located behind HTTPS with untrusted certificate).
+    In such case the old agent version will be used; you can replace slave.jar manually or to specify another download URL.
+  -->
+  <!-- <download from=\"TODO:jarFile\" to=\"%BASE%\\slave.jar\"/> -->
+  
+  <!-- 
+    In the case WinSW gets terminated and leaks the process, we want to abort
+    these runaway JAR processes on startup to prevent "Slave is already connected errors" (JENKINS-28492).
+    Will be enabled in WinSW 2.0 or higher
+  -->
+  <extensions>
+    <!-- This is a sample configuration for the RunawayProcessKiller extension. -->
+    <extension enabled="true" 
+               className="winsw.Plugins.RunawayProcessKiller.RunawayProcessKillerExtension"
+               id="killOnStartup">
+      <pidfile>%BASE%\jenkins_agent.pid</pidfile>
+      <stopTimeout>5000</stopTimeout>
+      <stopParentFirst>false</stopParentFirst>
+    </extension>
+  </extensions>
+  
+  <!-- See referenced examples for more options -->
+  
+</service>


### PR DESCRIPTION
In Jenkins 2.50 we have got [JENKINS-42724](https://issues.jenkins-ci.org/browse/JENKINS-42724), which has been caused by the usage of the old resource file located within the Jenkins core. It is likely a leftover from the migration of the windows-slaves-installer module.

Since the Windows Slaves plugin has its internal macro resolution logic, the sample should be also inside plugin. A longer-term fix is to make the plugin depend on the Windows Agent Installer module directly ([JENKINS-42743](https://issues.jenkins-ci.org/browse/JENKINS-42743), but it is blocked by [JENKINS-42745](https://issues.jenkins-ci.org/browse/JENKINS-42745)).

@reviewbybees 