### PR TITLE
Put double quotes around argument for port.txt file

### DIFF
--- a/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
+++ b/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
@@ -456,7 +456,7 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
     private String createAndCopyJenkinsSlaveXml(String java, String serviceId, PrintStream logger, SmbFile remoteRoot) throws IOException {
         logger.println(Messages.ManagedWindowsServiceLauncher_CopyingSlaveXml(getTimestamp()));
         String xml = generateSlaveXml(getClass(), serviceId,
-                java + "w.exe", vmargs, "-tcp %BASE%\\port.txt");
+                java + "w.exe", vmargs, "-tcp \"%BASE%\\port.txt\"");
         copyStreamAndClose(new ByteArrayInputStream(xml.getBytes("UTF-8")), new SmbFile(remoteRoot,"jenkins-slave.xml").getOutputStream());
         return xml;
     }


### PR DESCRIPTION
The windows slave service was failing to start. The windows slaves plugin was running java with an unquoted command line argument which included "Program Files" - so the windows slave was complaining that it couldn't find C:\Program.