### PR TITLE
Update Jenkins core to newer baseline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.12</version>
+        <version>2.36</version>
     </parent>
     <artifactId>windows-slaves</artifactId>
     <version>1.3.2-SNAPSHOT</version>
@@ -24,8 +24,8 @@
        <tag>HEAD</tag>
    </scm>
    <properties>
-       <jenkins.version>1.580.1</jenkins.version>
-       <java.level>6</java.level>
+       <jenkins.version>1.625.3</jenkins.version>
+       <java.level>7</java.level>
    </properties>
    <developers>
        <developer>
@@ -55,13 +55,13 @@
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 </project>


### PR DESCRIPTION
I am about making some patches in the repository, and for me it seems there is no need to keep maintaining Java 6 compatibility in the plugin. Even Java 7 is EoL.

@reviewbybees 