### PR TITLE
[JENKINS-47448] Update auto-installed jdk version to jdk-8u144

### DIFF
--- a/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
+++ b/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
@@ -232,7 +232,7 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
                 int exitCode = proc.waitFor();
                 if (exitCode==1) {// we'll get this error code if Java is not found
                     logger.println("No Java found. Downloading JDK");
-                    JDKInstaller jdki = new JDKInstaller("jdk-6u16-oth-JPR@CDS-CDS_Developer",true);
+                    JDKInstaller jdki = new JDKInstaller("jdk-8u144-oth-JPR",true);
                     URL jdk = jdki.locate(listener, Platform.WINDOWS, CPU.i386);
 
                     listener.getLogger().println("Installing JDK");

--- a/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
+++ b/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
@@ -233,7 +233,7 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
                 if (exitCode==1) {// we'll get this error code if Java is not found
                     logger.println("No Java found. Downloading JDK");
                     JDKInstaller jdki = new JDKInstaller("jdk-8u144-oth-JPR",true);
-                    URL jdk = jdki.locate(listener, Platform.WINDOWS, CPU.i386);
+                    URL jdk = jdki.locate(listener, Platform.WINDOWS, CPU.of(node));
 
                     listener.getLogger().println("Installing JDK");
                     copyStreamAndClose(jdk.openStream(), new SmbFile(remoteRoot, "jdk.exe").getOutputStream());


### PR DESCRIPTION
See [JENKINS-47448](https://issues.jenkins-ci.org/browse/JENKINS-47448).

This updates the version of the JDK installed automatically when Java is not found from `jdk-6u16` to `jdk-8u144`.

I would also support removing this feature and requiring that java be installed on the Windows agents separately.

@reviewbybees 