### PR TITLE
Rename the Windows Slaves Plugin to WMI Windows Agents Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,9 +11,9 @@
     <artifactId>windows-slaves</artifactId>
     <version>1.3.2-SNAPSHOT</version>
     <packaging>hpi</packaging>
-    <name>Windows Agents Plugin</name>
-    <description>Allows you to connect to Windows machines and start slave agents on them.</description>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Windows+Slaves+Plugin</url>
+    <name>WMI Windows Agents Plugin</name>
+    <description>Allows you to setup agents on Windows machines over Windows Management Instrumentation (WMI)</description>
+    <url>https://wiki.jenkins.io/display/JENKINS/Windows+Slaves+Plugin</url>
     <licenses>
         <license>
             <name>MIT</name>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <?jelly escape-by-default='true'?>
 <div>
-    Allows you to connect to Windows machines and start agents on them.
+    Allows you to setup agents on Windows machines over Windows Management Instrumentation (WMI)
 </div>


### PR DESCRIPTION
I am about releasing a new version of the plugin, and I would like to stop confusion about what the plugin does. This plugin **DOES NOT** provide support of Windows agents in general, Jenkins core does. This plugin just installs agents as services over WMI.

WMI is a major concern in recent Windows version, because WMI and DCOM are disabled/restricted in many ways. It is still possible to run the plugin against Windows 10, but it requires huge configuration.

@jenkinsci/code-reviewers esp. @slide @batmat @jenkinsci/sig-platform 

