### PR TITLE
Java 11 readiness: build both on JDK8 and JDK11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,1 @@
-#!/usr/bin/env groovy
-
-/* `buildPlugin` step provided by: https://github.com/jenkins-infra/pipeline-library */
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.31</version>
+        <version>3.47</version>
     </parent>
 
     <artifactId>windows-slaves</artifactId>
@@ -40,8 +40,8 @@
     </scm>
 
     <properties>
-        <jenkins.version>1.625.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.121.1</jenkins.version>
+        <java.level>8</java.level>
     </properties>
 
     <dependencies>
@@ -55,6 +55,11 @@
                     <artifactId>tiger-types</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jdk-tool</artifactId>
+            <version>1.3</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/hudson/os/windows/WindowsRemoteLauncher.java
+++ b/src/main/java/hudson/os/windows/WindowsRemoteLauncher.java
@@ -49,7 +49,7 @@ public class WindowsRemoteLauncher extends Launcher {
     public Proc launch(ProcStarter ps) throws IOException {
         FilePath pwd = ps.pwd();
         if (pwd == null) {
-            throw new IOException();
+            throw new IOException("Cannot access the process location.");
         }
         maskedPrintCommandLine(ps.cmds(), ps.masks(), pwd);
 
@@ -118,7 +118,7 @@ public class WindowsRemoteLauncher extends Launcher {
     @Override
     public Channel launchChannel(String[] cmd, OutputStream out, FilePath _workDir, Map<String, String> envVars) throws IOException, InterruptedException {
         if (_workDir == null) {
-            throw new IOException();
+            throw new IOException("Cannot access local process workdir.");
         }
         printCommandLine(cmd, _workDir);
 

--- a/src/main/java/hudson/os/windows/WindowsRemoteLauncher.java
+++ b/src/main/java/hudson/os/windows/WindowsRemoteLauncher.java
@@ -47,7 +47,11 @@ public class WindowsRemoteLauncher extends Launcher {
 
     @Override
     public Proc launch(ProcStarter ps) throws IOException {
-        maskedPrintCommandLine(ps.cmds(), ps.masks(), ps.pwd());
+        FilePath pwd = ps.pwd();
+        if (pwd == null) {
+            throw new IOException();
+        }
+        maskedPrintCommandLine(ps.cmds(), ps.masks(), pwd);
 
         // TODO: environment variable handling
 
@@ -55,7 +59,7 @@ public class WindowsRemoteLauncher extends Launcher {
 
         final Process proc;
         try {
-            proc = launcher.launch(buildCommandLine(ps), ps.pwd().getRemote());
+            proc = launcher.launch(buildCommandLine(ps), pwd.getRemote());
         } catch (JIException | InterruptedException e) {
             throw new IOException(e);
         }
@@ -113,6 +117,9 @@ public class WindowsRemoteLauncher extends Launcher {
 
     @Override
     public Channel launchChannel(String[] cmd, OutputStream out, FilePath _workDir, Map<String, String> envVars) throws IOException, InterruptedException {
+        if (_workDir == null) {
+            throw new IOException();
+        }
         printCommandLine(cmd, _workDir);
 
         try {


### PR DESCRIPTION
Work in progress to make sure this plugin is constantly checked both building with JDK8 and JDK11.

This goes with the Jenkins Java 11 General Availability announcement made back in March, and we're making a pass to check plugins are looking good on a JDK11.

([to understand the Jenkinsfile content](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime))
