### PR TITLE
Replace esclave with agent in the French localization

### DIFF
--- a/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/help-host_fr.html
+++ b/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/help-host_fr.html
@@ -1,3 +1,3 @@
 <div>
-    Fournissez le nom de la machine Windows s'il est diff&eacute;rent du nom de l'esclave.
+    Fournissez le nom de la machine Windows s'il est diff&eacute;rent du nom de l'agent.
 </div>

--- a/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/help_fr.properties
+++ b/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/help_fr.properties
@@ -20,6 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-blurb=Lance un esclave Windows en utilisant <a href="http://en.wikipedia.org/wiki/Windows_Management_Instrumentation">un système de gestion à distance</a> intégré à Windows. \
-  Cela convient uniquement pour gérer des esclaves sous Windows. \
-  Les esclaves doivent être accessibles par IP par le maître.
+blurb=Lance un agent Windows en utilisant <a href="http://en.wikipedia.org/wiki/Windows_Management_Instrumentation">un syst\u00E8me de gestion \u00E0 distance</a> int\u00E9gr\u00E9 \u00E0 Windows. \
+  Cela convient uniquement pour g\u00E9rer des agents sous Windows. \
+  Les agents doivent \u00EAtre accessibles par IP par le ma\u00EEtre.

--- a/src/main/resources/hudson/os/windows/Messages_fr.properties
+++ b/src/main/resources/hudson/os/windows/Messages_fr.properties
@@ -21,9 +21,9 @@
 # THE SOFTWARE.
 
 ManagedWindowsServiceLauncher.DisplayName=\
-  Permet \u00e0 Jenkins de contr\u00f4ler cet esclave Windows en tant que service Windows
-ManagedWindowsServiceLauncher.DotNetRequired={0} [windows-agents] Le Framework .NET version 2.0 ou plus est n\u00e9cessaire sur cet ordinateur pour lancer un esclave Jenkins en tant que service Windows
-ManagedWindowsServiceLauncher.InstallingAgentService={0} [windows-agents] Installation du service esclave Windows
+  Permet \u00e0 Jenkins de contr\u00f4ler cet agent Windows en tant que service Windows
+ManagedWindowsServiceLauncher.DotNetRequired={0} [windows-agents] Le Framework .NET version 2.0 ou plus est n\u00e9cessaire sur cet ordinateur pour lancer un agent Jenkins en tant que service Windows
+ManagedWindowsServiceLauncher.InstallingAgentService={0} [windows-agents] Installation du service agent Windows
 ManagedWindowsServiceLauncher.ConnectingTo={0} [windows-agents] Connexion \u00e0 {1}
 ManagedWindowsServiceLauncher.ConnectingToPort={0} [windows-agents] Connexion au port {1}
 ManagedWindowsServiceLauncher.UnknownHost={0} Le nom d''h\u00f4te {1} est inconnu du serveur de noms. Veuillez v\u00e9rifier que le nom de la machine est correct.


### PR DESCRIPTION
The word esclave(s) appeared in the French documentation for the windows-slaves plugin; I changed it to agent(s) (consistent with previous PRs).

For some reason, the accents were broken for me in the java .properties file, so I changed them to the unicode versions according to this stack overflow thread: https://stackoverflow.com/questions/27363614/java-properties-file-with-accented-characters.