### PR TITLE
[JENKINS-63223] - Stop passing jenkins.exe.config is no longer available in the Core + Update Minimum Jenkins Core requirement to 2.249.1 + Use Bills of materials to specify core and plugin dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ out
 .settings
 .classpath
 .project
+.factorypath
 build
 
 # vim

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "11", jenkins: null, javaLevel: 8 ]
+])

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,5 @@
-buildPlugin(configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(/*...*/, configurations: [
+  [ platform: "linux", jdk: "8", jenkins: null ],
+  [ platform: "windows", jdk: "8", jenkins: null ],
+  [ platform: "linux", jdk: "11", jenkins: null, javaLevel: 8 ]
+])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.53</version>
+        <version>4.8</version>
     </parent>
 
     <artifactId>windows-slaves</artifactId>
@@ -43,8 +43,19 @@
     <properties>
         <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
-        <configuration-as-code.version>1.36</configuration-as-code.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.249.x</artifactId>
+                <version>12</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -61,18 +72,15 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jdk-tool</artifactId>
-            <version>1.3</version>
         </dependency>
         <dependency>
             <groupId>io.jenkins</groupId>
             <artifactId>configuration-as-code</artifactId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.jenkins.configuration-as-code</groupId>
             <artifactId>test-harness</artifactId>
-            <version>${configuration-as-code.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </scm>
 
     <properties>
-        <jenkins.version>2.121.1</jenkins.version>
+        <jenkins.version>2.249.1</jenkins.version>
         <java.level>8</java.level>
         <configuration-as-code.version>1.36</configuration-as-code.version>
     </properties>

--- a/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
+++ b/src/main/java/hudson/os/windows/ManagedWindowsServiceLauncher.java
@@ -295,8 +295,6 @@ public class ManagedWindowsServiceLauncher extends ComputerLauncher {
                 // Ideally the resources from Windows Agent Installer Module should be used instead (JENKINS-42743)
                 copyStreamAndClose(getClass().getResource("/windows-service/jenkins.exe").openStream(), new SmbFile(remoteRoot, "jenkins-agent.exe").getOutputStream());
 
-                copyStreamAndClose(getClass().getResource("/windows-service/jenkins.exe.config").openStream(), new SmbFile(remoteRoot, "jenkins-agent.exe.config").getOutputStream());
-
                 copyAgentJar(logger, remoteRoot);
 
                 // copy jenkins-agent.xml


### PR DESCRIPTION
jenkins.exe.config was removed from Jenkins, copy attempt fails with NullPointerException