### PR TITLE
[JENKINS-51820] Editing text related to `JNLPLauncher`

### DIFF
--- a/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/config.properties
+++ b/src/main/resources/hudson/os/windows/ManagedWindowsServiceLauncher/config.properties
@@ -1,3 +1,3 @@
 blurb=\
     This launch method relies on DCOM and is often associated with <a href="https://github.com/jenkinsci/windows-slaves-plugin/blob/master/docs/troubleshooting.adoc" target="_blank">subtle problems</a>. \
-    Consider using <b>Launch agents using Java Web Start</b> instead, which also permits installation as a Windows service but is generally considered more reliable.
+    Consider using <b>Launch agent by connecting it to the controller</b> instead, which is also compatible with installation as a Windows service but is generally considered more reliable.


### PR DESCRIPTION
The inbound connection method was long since renamed to not refer to JWS/JNLP, and as of https://github.com/jenkinsci/jenkins/pull/6543 will not use JWS/JNLP at all. Also trying to rephrase note about installation as a Windows service, since https://github.com/jenkinsci/jenkins/pull/6543 also removes https://github.com/jenkinsci/windows-slave-installer-module.

@slide’s https://groups.google.com/g/jenkinsci-dev/c/D9y66Oh82sg/m/njVOL-HLAAAJ made me think of this (also CC @MarkEWaite).