### PR TITLE
Bump jenkins baseline, bom version and parent pom

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 
 buildPlugin(configurations: [
-  [ platform: "linux", jdk: "8", jenkins: null ],
-  [ platform: "windows", jdk: "8", jenkins: null ],
-  [ platform: "linux", jdk: "11", jenkins: null, javaLevel: 8 ]
+  [ platform: "linux"  , jdk: "11" ],
+  [ platform: "windows", jdk: "11" ],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.8</version>
+        <version>4.50</version>
     </parent>
 
     <artifactId>windows-slaves</artifactId>
@@ -41,16 +41,15 @@
     </scm>
 
     <properties>
-        <jenkins.version>2.249.1</jenkins.version>
-        <java.level>8</java.level>
+        <jenkins.version>2.361.4</jenkins.version>
     </properties>
 
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.249.x</artifactId>
-                <version>12</version>
+                <artifactId>bom-2.361.x</artifactId>
+                <version>1678.vc1feb_6a_3c0f1</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
The existing versions where too old to properly run the PCT against the upcoming 2.375 LTS line due to and old version of the jenkins test harness. Instead of updating the jenkins test harness alone I believe is better to update the parent and the bom that were already out of date

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
